### PR TITLE
Fix issue #15

### DIFF
--- a/checks/Makefile.am
+++ b/checks/Makefile.am
@@ -50,7 +50,10 @@ if BUILD_palogist
 check_SCRIPTS += test_bt.sh test_flipmaf_palogist.sh
 endif
 if BUILD_pacoxph
-check_SCRIPTS += test_cox.sh test_cox_nocovar.sh test_flipmaf_pacoxph.sh
+check_SCRIPTS += test_cox.sh			\
+ test_cox_nocovar.sh				\
+ test_cox_interactions.sh			\
+ test_flipmaf_pacoxph.sh
 endif
 
 AM_TESTS_ENVIRONMENT= \
@@ -189,6 +192,26 @@ coxph_prob_nocovar_add.out.txt				\
 coxph_prob_nocovar_2df.out.txt				\
 coxph_prob_nocovar_fv_2df.out.txt
 
+cleanfiles_cox_interaction = coxph_dose_int1_add.out.txt	\
+coxph_prob_int1_over_domin.out.txt				\
+coxph_prob_int1_domin.out.txt					\
+coxph_prob_int1_recess.out.txt					\
+coxph_prob_int1_add.out.txt					\
+coxph_prob_int1_2df.out.txt					\
+coxph_dose_int2_add.out.txt					\
+coxph_prob_int2_over_domin.out.txt				\
+coxph_prob_int2_domin.out.txt					\
+coxph_prob_int2_recess.out.txt					\
+coxph_prob_int2_add.out.txt					\
+coxph_prob_int2_2df.out.txt					\
+coxph_dose_int3_add.out.txt					\
+coxph_prob_int3_over_domin.out.txt				\
+coxph_prob_int3_domin.out.txt					\
+coxph_prob_int3_recess.out.txt					\
+coxph_prob_int3_add.out.txt					\
+coxph_prob_int3_2df.out.txt
+
+
 cleanfiles_cox_flipmaf = coxph_flipmaf_add.out.txt	\
 coxph_flipmaf_fv_add.out.txt				\
 coxph_prob_flipmaf_2df.out.txt				\
@@ -236,4 +259,5 @@ cleanfiles_dose_check = test.mldose
 CLEANFILES = $(cleanfiles_probabel_check) $(cleanfiles_dose_check)	\
  $(cleanfiles_bt) $(cleanfiles_bt_flipmaf) $(cleanfiles_qt)		\
  $(cleanfiles_qt_flipmaf) $(cleanfiles_mms) $(cleanfiles_cox)		\
- $(cleanfiles_cox_nocovar) $(cleanfiles_cox_flipmaf)
+ $(cleanfiles_cox_nocovar) $(cleanfiles_cox_interaction)		\
+ $(cleanfiles_cox_flipmaf)

--- a/checks/test_cox_interactions.sh
+++ b/checks/test_cox_interactions.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# This script runs checks on ProbABEL's pacoxph module
+
+echo "Analysing Cox model with interactions..."
+
+scriptdir=$(dirname $0)
+
+if [ -z ${PA_BINDIR} ]; then
+    PA_BINDIR="${scriptdir}/../src/"
+fi
+if [ -z ${srcdir} ]; then
+    srcdir="."
+    PA_BINDIR=${scriptdir}/../src/
+fi
+
+. ${scriptdir}/run_diff.sh
+
+inputdir=${scriptdir}/inputfiles
+pacoxph=${PA_BINDIR}/pacoxph
+
+# Redirect all output to file descriptor 3 to /dev/null except if
+# the first argument is "verbose" then redirect handle 3 to stdout
+exec 3>/dev/null
+if [ "$1" = "verbose" ]; then
+    echo "Verbose mode ON"
+    exec 3>&1
+fi
+
+for covar in {1..3}; do
+    echo "Option --interaction=${covar}"
+    $pacoxph \
+        -p ${inputdir}/coxph_data.txt \
+        -d ${inputdir}/test.mldose \
+        -i ${inputdir}/test.mlinfo \
+        -m ${inputdir}/test.map \
+        -c 19 \
+        --interaction=${covar} \
+        -o coxph_dose_int${covar} \
+        >& 3
+    $pacoxph \
+        -p ${inputdir}/coxph_data.txt \
+        -d ${inputdir}/test.mlprob \
+        -i ${inputdir}/test.mlinfo \
+        -m ${inputdir}/test.map \
+        --ngpreds=2 \
+        -c 19 \
+        --interaction=${covar} \
+        -o coxph_prob_int${covar} \
+        >& 3
+
+    run_diff coxph_dose_int${covar}_add.out.txt \
+             coxph_prob_int${covar}_add.out.txt \
+             "pacoxph check --interaction=${covar}: dose vs. prob"
+done

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,6 +1,10 @@
 ***** v.0.5.0 (2016.)
 * ProbABEL now depends on the Eigen library. The option to compile without
   Eigen has been removed.
+* Fixed Issue #15: Coxph interactions not working; when using the
+  --interaction option the name of the model was wrong (e.g. for
+  --interaction=1, the interaction term was shown as mu * SNP_A1, which
+  obviously is not what we meant to do).
 * Fixed issue Github #16: "Too many NANs for SNPs with low `Rsq` when some
   commandline options are specified"
 * Added --flipmaf command line option to palinear, pacoxph and palogist.

--- a/src/phedata.cpp
+++ b/src/phedata.cpp
@@ -164,16 +164,9 @@ void phedata::setphedata(const char * fname, const int noutc,
     model = model + " + SNP_A1";
     if (interaction != 0)
     {
-        if (iscox)
-        {
             model = model + " + "
-                + model_terms[interaction - 1]
+                + model_terms[interaction]
                 + "*SNP_A1";
-        }
-        else
-        {
-            model = model + " + " + model_terms[interaction] + "*SNP_A1";
-        }
     }
     model_terms[n_model_terms++] = "SNP_A1";
 

--- a/src/reg1.cpp
+++ b/src/reg1.cpp
@@ -102,31 +102,15 @@ mematrix<double> apply_model(const mematrix<double>& X,
 
             for (int i = 0; i < nX.nrow; i++)
             {
-                if (iscox)
+                // Maksim: interaction with SNP;;
+                nX[i * nX.ncol + c1] =
+                    X[i * X.ncol + csnp_p1]
+                    * X[i * X.ncol + interaction];
+                if (ngpreds == 2)
                 {
-                    // Maksim: interaction with SNP;;
-                    nX[i * nX.ncol + c1] =
-                        X[i * X.ncol + csnp_p1]
-                        * X[i * X.ncol + interaction - 1];
-                    if (ngpreds == 2)
-                    {
-                        nX[i * nX.ncol + c2] =
-                            X[i * X.ncol + csnp_p2]
-                            * X[i * X.ncol + interaction - 1];
-                    }
-                }
-                else
-                {
-                    // Maksim: interaction with SNP;;
-                    nX[i * nX.ncol + c1] =
-                        X[i * X.ncol + csnp_p1]
+                    nX[i * nX.ncol + c2] =
+                        X[i * X.ncol + csnp_p2]
                         * X[i * X.ncol + interaction];
-                    if (ngpreds == 2)
-                    {
-                        nX[i * nX.ncol + c2] =
-                            X[i * X.ncol + csnp_p2]
-                            * X[i * X.ncol + interaction];
-                    }
                 }
             }
 


### PR DESCRIPTION
This fixes the `--interactions` option when using pacoxph. With the
introduction of the (mathematically useless) \mu in the Cox model (which
was introduced to fix [bug 1266 (pacoxph with no covariates) on R-forge](https://r-forge.r-project.org/tracker/index.php?func=detail&aid=1266&group_id=505&atid=2058)),
the extra parts of code where we adjusted for the missing \mu were
inadvertently kept. Cox + interactions must have been broken since then.
