### PR TITLE
Fix compiler errors about static const double on GCC 6.2.0

### DIFF
--- a/src/coxph_data.h
+++ b/src/coxph_data.h
@@ -220,13 +220,13 @@ class coxph_reg {
      * Iteration continues until the percent change in loglikelihood
      * is <= EPS.
      */
-    static const double EPS = 1e-9;
+    static constexpr double EPS = 1e-9;
 
     /**
      * \brief Constant containing the precision for the Cholesky
      * decomposition.
      */
-    static const double CHOLTOL = 1.5e-12;
+    static constexpr double CHOLTOL = 1.5e-12;
 };
 
 #endif /* COXPH_DATA_H_ */

--- a/src/reg1.h
+++ b/src/reg1.h
@@ -185,7 +185,7 @@ class logistic_reg: public base_reg {
      * Iteration continues until the percent change in loglikelihood
      * is <= EPS.
      */
-    static const double EPS = 1e-8;
+    static constexpr double EPS = 1e-8;
 };
 
 #endif // REG1_H_


### PR DESCRIPTION
This fixes issue #32.

See e.g.
https://en.wikipedia.org/wiki/C%2B%2B11#constexpr_.E2.80.93_Generalized_constant_expressions
and http://en.cppreference.com/w/cpp/language/constexpr