### PR TITLE
Fix memory leak (issue #31)

### DIFF
--- a/src/regdata.cpp
+++ b/src/regdata.cpp
@@ -255,6 +255,7 @@ void regdata::update_snp(const gendata *gend,
             }  // End if std::isnan(snpdata[i]) snp
         }  // End for loop: i = 0 to nids
 
+        delete[] PA1A2;
         delete[] snpdata;
     }  // End for loop: j = 0 to ngpreds
 


### PR DESCRIPTION
This fixes a memory leak introduced when implementing the `--flipmaf`option (see Issue #5) in commit 4bbe442f69eefef0c3e9458dc05121c5263723e9.