### PR TITLE
Force the use of the C++11 standard with compiler flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,13 +38,13 @@ if test "x$devoptions" = "xyes"; then
       # User did not set CPPFLAGS, so we can put in our own defaults
       CPPFLAGS="-Wall"
    fi
-   CXXFLAGS+=" -g"
+   CXXFLAGS+=" -g -std=c++11"
 fi
 
 if test "x$devoptions" = "xno"; then
    if test -z "$CXXFLAGS"; then
       # User did not set CXXFLAGS, so we can put in our own defaults
-      CXXFLAGS="-O2"
+      CXXFLAGS="-O2 -std=c++11"
    fi
    if test -z "$CPPFLAGS"; then
       # User did not set CPPFLAGS, so we can put in our own defaults


### PR DESCRIPTION
After fixing the compile issue (#32) with GCC 6.5.0 compilation failed
on older GCC versions (at least on 5.4.0). With this commit we
explicitly add -std=c++11 to the CXXFLAGS in configure.ac.

This means that the minimum GCC version is now 4.8.1, because that was
the first version that was feature-complete with the C++11 standard.