### PR TITLE
Fix a memory leak in pacoxph

### DIFF
--- a/src/coxph_data.cpp
+++ b/src/coxph_data.cpp
@@ -390,6 +390,7 @@ void coxph_data::update_snp(const gendata *gend,
             }    // end std::isnan(snpdata[i]) snp
         }    // end for loop: i=0 to nids
 
+        delete[] PA1A2;
         delete[] snpdata;
     }    // End for loop: j=0 to ngpreds
 


### PR DESCRIPTION
This relates to issue #31 and is similar to the fix in PR #34/commit
0253d01b17b7bc7396cfb8a5fc3df6aac086879a.

Signed-off-by: L.C. Karssen <lennart@karssen.org>