### PR TITLE
Update manual/ChangeLog with info on gzipped files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,16 @@
 # /doc/
 /doc/Makefile.in
 /doc/doxygen-docs
+/doc/ProbABEL_manual.aux
+/doc/ProbABEL_manual.idx
+/doc/ProbABEL_manual.ilg
+/doc/ProbABEL_manual.ind
+/doc/ProbABEL_manual.log
+/doc/ProbABEL_manual.out
+/doc/ProbABEL_manual.pdf
+/doc/ProbABEL_manual.synctex.gz
+/doc/ProbABEL_manual.toc
+/doc/auto/
 
 # /examples/
 /examples/Makefile.in

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,9 @@
 ***** v.0.x.0 ()
+* ProbABEL can now read gzipped info files, map files, invsigma files and
+  genotype data. This requires that the Boost IOStream library is
+  installed when compiling. For clarity: reading from gzipped
+  DatABEL/filevector files is not supported (as it would defeat the
+  purpose of fast access to the data).
 * Removed the requirement on having 7 columns in the info file. However,
   it is the user's responsibility to make sure the first 7 columns contain
   the right information.

--- a/doc/ProbABEL_manual.tex
+++ b/doc/ProbABEL_manual.tex
@@ -271,21 +271,29 @@ directory \texttt{/home/yourusername/ProbABEL/bin/}. You are now ready
 to analyse your data!
 
 \section{Input files}
-\PA{} takes three files as input: a file containing SNP
-information (e.g.~the MLINFO file of MaCH), a file with genome- or
-chromosome-wide predictor information (e.g.~the MLDOSE or MLPROB file
-of MaCH or \texttt{minimac}),
-and a file containing the phenotype of interest and covariates.
+\PA{} takes three files as input: a file containing SNP information
+(e.g.~the MLINFO file of MaCH), a file with genome- or chromosome-wide
+predictor information (e.g.~the MLDOSE or MLPROB file of MaCH or
+\texttt{minimac}), and a file containing the phenotype of interest and
+covariates. Optionally, a file with map information can be supplied
+(e.g.~the "legend" files of HapMap). Except for the phenotype file,
+each of these files may be gzipped to save disk space\footnote{This
+  requires that the Boost IOStream library is present when ProbABEL is
+  compiled from source (see \url{http://www.boost.org/doc/libs/}).}.
 
-Optionally, the map information can be supplied (e.g.~the "legend"
-files of HapMap).
-
-The dose/probability file may be supplied in filevector format
-in which case \PA{} will operate much faster, and
-in low-RAM mode (approx.~128 MB). See the R libraries \GA{} and
-\DA{} on how to convert MaCH and IMPUTE2 files to
-filevector format (functions: \texttt{mach2databel()} and
+As an alternative to (gzipped) text files, the dose/probability file
+may be supplied in filevector format\footnote{Note that filevector
+  files should not be gzipped. ProbABEL won't be able to read gzipped
+  filevector files. Compressing filevector files in a simple manner as
+  gzip does will remove the speed benefit that filevector files have
+  over text files (gzipped or not).} in which case \PA{} will operate
+much faster, and in low-RAM mode (approx.~128 MB). See the R libraries
+\GA{} and \DA{} on how to convert MaCH and IMPUTE2 files to filevector
+format (functions: \texttt{mach2databel()} and
 \texttt{impute2databel()}, respectively).
+
+More information on each of these input files can be found in the following
+subsections.
 
 \subsection{SNP information file}
 \label{ssec:infoin}


### PR DESCRIPTION
This commit adds information on reading from gzipped files to the manual and changelog. 

I think this implements everything needed to close issue #12 (reading of gzipped files). We could add reading of gzipped phenotype files as well, but since most people create these from R, I guess they won't bother to zip them. Moreover, the phenotype file is currently opened and closed several times in the process of extracting all phenotype info (determining nr of samples and covariates, finding out which lines have NAs, etc), so doing that for a zipped file would be more time consuming. Implementing a "read phenotype data once" strategy in the current code isn't trivial either. 