### PR TITLE
CI/CD: add build job

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,12 @@
+name: build
+run-name: ProbABEL build
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: apt install -y build-essential
+      - run: autoreconf -i
+      - run: ./configure
+      - run: make


### PR DESCRIPTION
This is a first attempt at implementing CI/CD for ProbABEL. Here, we add a build job that configures the project and runs make.