### PR TITLE
CICD fix: use sudo for Ubuntu package installation

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: apt install -y build-essential
+      - run: sudo apt install -y build-essential
       - run: autoreconf -i
       - run: ./configure
       - run: make


### PR DESCRIPTION
Github Actions VMs have passwordless sudo, so we'll need to add that to the apt install line